### PR TITLE
$.modal().close() not use overlay options, defined on open

### DIFF
--- a/jquery.the-modal.js
+++ b/jquery.the-modal.js
@@ -155,7 +155,7 @@
 				if(localOptions.closeOnEsc) {
 					$(document).bind('keyup.'+pluginNamespace, function(e){
 						if(e.keyCode === 27) {
-                            $.modal().close();
+							$.modal().close();
 						}
 					});
 				}
@@ -165,7 +165,7 @@
 						e.stopPropagation();
 					});
 					$('.' + localOptions.overlayClass).on('click.' + pluginNamespace, function(e){
-                        $.modal().close();
+						$.modal().close();
 					});
 				}
 


### PR DESCRIPTION
Referenced and fix #39.

In previous PR, which solve #39, forgotten the case, when the context is not available, e.g. closing modal by clicking close button (and calling `$.modal().close()`) in demo.

I change options, which saved on `init` call in overlay options.
Before: `options`(`$.modal(options).close()`)
Now: `localOptions` - all merged options, which use `init` function. It allows on modal closing use settings, which have been passed to this modal instance on initializing.
