### PR TITLE
Stop hijacking ctrl+A when an input is focused

### DIFF
--- a/jquery.the-modal.js
+++ b/jquery.the-modal.js
@@ -123,6 +123,10 @@
 				return true;
 			}
 
+			if ( $('input:focus, textarea:focus').length > 0 ) {
+			    return true;
+			}
+
 			var selectAllEvent = new $.Event('onSelectAll');
 			selectAllEvent.parentEvent = e;
 			$(window).trigger(selectAllEvent);


### PR DESCRIPTION
#10 introduced behavior to select text only in the modal, but it also made it such that when a user is in a text field (e.g. a username field) and wants to select the text they have entered with ctrl+a, it doesn't work as expected. Instead of selecting the text in the text field, it selects all of the modal text.

This tests to see if any input fields have focus before firing onSelectAll.