### PR TITLE
Fix closeOnOverlayClick option

### DIFF
--- a/jquery.the-modal.js
+++ b/jquery.the-modal.js
@@ -178,7 +178,7 @@
 				if(localOptions.closeOnOverlayClick) {
 					$('.' + localOptions.overlayClass).on('click.' + pluginNamespace, function(e){
 						if (e.target.className == localOptions.overlayClass){
-							$.modal().close();
+							$.modal().close(localOptions);
 						}
 					});
 				}


### PR DESCRIPTION
The patch I grabbed from #25 actually broke the close on overlay click feature, the close call should have localOptions passed in. This makes that actually work again. Sorry for not actually testing the patch properly :/